### PR TITLE
Compute the normalized alpha-diversity in the back-end and show it in the front-end.

### DIFF
--- a/src/client/app/components/alpha-diversity-computation/alpha-diversity-computation-controller.js
+++ b/src/client/app/components/alpha-diversity-computation/alpha-diversity-computation-controller.js
@@ -108,6 +108,7 @@ AlphaDiversityComputationCtrl.prototype.showSamples = function() {
 		 	this.samples = response.data;
 			for (let i=0; i<this.samples.length; i++) {
 				this.samples[i].alphaDiversity = '_';
+				this.samples[i].normalizedAlphaDiversity = '_';
 				this.samples[i].alphaDiversityComputationStatus = {
 					started: false,
 					completed: false,
@@ -152,6 +153,8 @@ AlphaDiversityComputationCtrl.prototype.toggleVisibility = function() {
  * @param {string} sample.orderOfDiversity Denoted by 'q', it is an important factor in determining
  *																				 the weight assigned to a species.
  * @param {string} sample.alphaDiversity  The alpha diversity of the sample.
+ * @param {string} sample.normalizedAlphaDiversity  The normalized alpha diversity of the sample,
+																										if possible to compute.
  * @param {Object} sample.alphaDiversityComputationStatus  Has two properties - 'started' and
  *																												 'completed' denoting whether the 
  *																												 computation has started or not and
@@ -161,6 +164,7 @@ AlphaDiversityComputationCtrl.prototype.toggleVisibility = function() {
 AlphaDiversityComputationCtrl.prototype.computeAlphaDiversity = function(sample) {
 	// Refresh the alpha-diversity computation status and alpha-diversity.
 	sample.alphaDiversity = '_';
+	sample.normalizedAlphaDiversity = '_';
 	sample.alphaDiversityComputationStatus = {
 		started: false,
 		completed: false,
@@ -185,7 +189,8 @@ AlphaDiversityComputationCtrl.prototype.computeAlphaDiversity = function(sample)
 					this.window_.alert('Internal server error!');
 				} else {
 					sample.alphaDiversityComputationStatus.completed = true;
-					sample.alphaDiversity = response.data;
+					sample.alphaDiversity = response.data.alphaDiversity;
+					sample.normalizedAlphaDiversity = response.data.normalizedAlphaDiversity;
 					this.computeMeanAndStandardDeviationOfSelectedSamples_();
 				}
 			}).bind(this), (function(error) {

--- a/src/client/app/components/alpha-diversity-computation/alpha-diversity-computation.html
+++ b/src/client/app/components/alpha-diversity-computation/alpha-diversity-computation.html
@@ -46,6 +46,7 @@
 					<th>Order of Diversity(q)</th>
 					<th>Actions</th>
 					<th>Alpha-diversity</th>
+					<th>Normalized Alpha-diversity<br>(for q=1 only)</th>
 				</tr>			
 				<tr ng-repeat='sample in alphaDiversityComputationCtrl.samples track by $index'>
 					<td>{{$index+1}}</td>
@@ -71,16 +72,33 @@
 						<input type="checkbox" ng-model='sample.isIncluded.value' checkbox-mean-and-standard-deviation-trigger>
 					</td>
 					<td>
-					 <span ng-if='sample.alphaDiversityComputationStatus.started == false'>
-						 {{sample.alphaDiversity}}
-					 </span>
-					 <span ng-if='sample.alphaDiversityComputationStatus.started == true &&
-							 sample.alphaDiversityComputationStatus.completed == false'>
-						 <img height='50' width='50' src='assets/images/ball_loading.GIF'>
-					 </span>
-					 <span ng-if='sample.alphaDiversityComputationStatus.completed == true'>
-						 {{sample.alphaDiversity | number : 2}}
-					 </span>						
+						<span ng-if='sample.alphaDiversityComputationStatus.started === false'>
+							{{sample.alphaDiversity}}
+						</span>
+						<span ng-if='sample.alphaDiversityComputationStatus.started === true &&
+								sample.alphaDiversityComputationStatus.completed === false'>
+							<img height='50' width='50' src='assets/images/ball_loading.GIF'>
+						</span>
+						<span ng-if='sample.alphaDiversityComputationStatus.completed === true'>
+							{{sample.alphaDiversity | number : 2}}
+						</span>						
+					</td>
+					<td>
+						<span ng-if='sample.alphaDiversityComputationStatus.started === false'>
+							{{sample.normalizedAlphaDiversity}}
+						</span>
+						<span ng-if='sample.alphaDiversityComputationStatus.started === true &&
+								sample.alphaDiversityComputationStatus.completed === false'>
+							<img height='50' width='50' src='assets/images/ball_loading.GIF'>
+						</span>
+						<span ng-if='sample.alphaDiversityComputationStatus.completed === true'>
+							<span ng-if='+sample.orderOfDiversity === 1'>
+								{{sample.normalizedAlphaDiversity | number : 2}}
+							</span>
+							<span ng-if='+sample.orderOfDiversity !== 1'>
+								NA
+							</span>								
+						</span>						
 					</td>
 				</tr>
 			</table>		

--- a/src/server/forked_processes/alpha-diversity-computation-process.js
+++ b/src/server/forked_processes/alpha-diversity-computation-process.js
@@ -26,18 +26,22 @@ process.on('message', function(req) {
 					m += organisms[i].readcount;
 				}
 			}
-			let alphaDiversity;
+			let alphaDiversity, normalizedAlphaDiversity;
 			// If order of diversity is 1, then delegate to Shannon's index to compute
 			// alpha-diversity as mentioned here - 
 			// https://en.wikipedia.org/wiki/Diversity_index#Shannon_index
 			if (q === 1) {
 				alphaDiversity = 0;
+				let nonHostSpeciesCount = 0;
 				for (let i=0; i<organisms.length; i++) {
 					if (isNonHostSpecies(organisms[i]) === true) {
+						nonHostSpeciesCount++;
 						alphaDiversity -= (organisms[i].readcount === 0 ?
 								0 : (organisms[i].readcount/m) * Math.log(organisms[i].readcount/m));
 					}
 				}
+				normalizedAlphaDiversityInString =
+						(alphaDiversity/Math.log(nonHostSpeciesCount)).toString();
 			} else {
 				let basicSum = 0;
 				for (let i=0; i<organisms.length; i++) {
@@ -46,9 +50,13 @@ process.on('message', function(req) {
 					}
 				}
 				alphaDiversity = Math.pow(basicSum, 1-q);
+				normalizedAlphaDiversityInString = 'undefined';
 			}
 			logOnlyInNonTestEnvironment('Alpha-diversity of the file has been computed.');
-			process.send(alphaDiversity.toString());
+			process.send({
+				alphaDiversity: alphaDiversity.toString(),
+				normalizedAlphaDiversity: normalizedAlphaDiversityInString
+			});
 		}
 	};
 	request.send();

--- a/test/client/app/components/alpha-diversity-computation/alpha-diversity-computation-controller-test.js
+++ b/test/client/app/components/alpha-diversity-computation/alpha-diversity-computation-controller-test.js
@@ -15,6 +15,7 @@ describe('Unit tests for AlphaDiversityComputationCtrl', function() {
 			primaryClassificationRef,
 			orderOfDiversity,
 			alphaDiversity,
+			normalizedAlphaDiversity,
 			alphaDiversityComputationStarted,
 			alphaDiversityComputationCompleted,
 			isIncluded) {
@@ -24,6 +25,7 @@ describe('Unit tests for AlphaDiversityComputationCtrl', function() {
 					},
 					orderOfDiversity: orderOfDiversity,
 					alphaDiversity: alphaDiversity,
+					normalizedAlphaDiversity: normalizedAlphaDiversity,
 					alphaDiversityComputationStatus: {
 						started: alphaDiversityComputationStarted,
 						completed: alphaDiversityComputationCompleted
@@ -90,8 +92,8 @@ describe('Unit tests for AlphaDiversityComputationCtrl', function() {
 		it('should show \'_\' if one of the selected sample\'s alpha-diversity is not computed yet by the server',
 			function() {
 				ctrl.samples = [
-					createSample(undefined, undefined, '_', undefined, undefined, true),
-					createSample(undefined, undefined, '3.4', undefined, undefined, true)
+					createSample(undefined, undefined, '_', undefined, undefined, undefined, true),
+					createSample(undefined, undefined, '3.4', undefined, undefined, undefined, true)
 				];
 				ctrl.computeMeanAndStandardDeviationOfSelectedSamples_();
 				expect(ctrl.resultantMeanAndStandardDeviation).toEqual({
@@ -103,13 +105,14 @@ describe('Unit tests for AlphaDiversityComputationCtrl', function() {
 		it('should calculate the mean and standard-deviation of the selected samples',
 			function() {
 				ctrl.samples = [
-					createSample(undefined, undefined, '5', undefined, undefined, true),
-					createSample(undefined, undefined, '53434.5', undefined, undefined, true),
-					createSample(undefined, undefined, '4.9', undefined, undefined, true),
-					createSample(undefined, undefined, '4.85', undefined, undefined, true),
-					createSample(undefined, undefined, '87.45', undefined, undefined, true),
-					createSample(undefined, undefined, '23123312.2313', undefined, undefined, true),
-					createSample(undefined, undefined, '6435.0', undefined, undefined, true)
+					createSample(undefined, undefined, '5', undefined, undefined, undefined, true),
+					createSample(undefined, undefined, '53434.5', undefined, undefined, undefined, true),
+					createSample(undefined, undefined, '4.9', undefined, undefined, undefined, true),
+					createSample(undefined, undefined, '4.85', undefined, undefined, undefined, true),
+					createSample(undefined, undefined, '87.45', undefined, undefined, undefined, true),
+					createSample(
+							undefined, undefined, '23123312.2313', undefined, undefined, undefined, true),
+					createSample(undefined, undefined, '6435.0', undefined, undefined, undefined, true)
 				];
 				ctrl.computeMeanAndStandardDeviationOfSelectedSamples_();
 				let actualResultantMeanAndStandardDeviationAfterRoundingOff = {
@@ -140,12 +143,12 @@ describe('Unit tests for AlphaDiversityComputationCtrl', function() {
 
 		it('should show samples by setting proper variables', function() {
 			let responseSamples = [
-				createSample('ref1', undefined, undefined, undefined, undefined, undefined),
-				createSample('ref2', undefined, undefined, undefined, undefined, undefined),
+				createSample('ref1', undefined, undefined, undefined, undefined, undefined, undefined),
+				createSample('ref2', undefined, undefined, undefined, undefined, undefined, undefined)
 			];
 			let expectedSamples = [
-				createSample('ref1', undefined, '_', false, false, undefined),
-				createSample('ref2', undefined, '_', false, false, undefined),
+				createSample('ref1', undefined, '_', '_', false, false, undefined),
+				createSample('ref2', undefined, '_', '_', false, false, undefined),
 			]
 			httpMock.expectGET('https://app.onecodex.com/api/v1/samples', function(headers) {
 				return headers['Authorization'] === 'Basic mockbtoa==';
@@ -189,9 +192,9 @@ describe('Unit tests for AlphaDiversityComputationCtrl', function() {
 		
 		it('should alert the user if the order of diversity is not specified', function() {
 			let actualSample =
-					createSample(undefined, undefined, undefined, undefined, undefined, undefined);
+					createSample(undefined, undefined, undefined, undefined, undefined, undefined, undefined);
 			ctrl.computeAlphaDiversity(actualSample);
-			let expectedSample = createSample(undefined, undefined, '_', false, false, undefined);
+			let expectedSample = createSample(undefined, undefined, '_', '_', false, false, undefined);
 			expect(actualSample).toEqual(expectedSample);
 			expect(windowService.alert)
 					.toHaveBeenCalledWith('Please specify a valid order of diversity!');
@@ -202,6 +205,7 @@ describe('Unit tests for AlphaDiversityComputationCtrl', function() {
 					createSample(
 							'/api/v1/classifications/testRef',
 							'2',
+							undefined, 
 							undefined,
 							undefined,
 							undefined,
@@ -238,11 +242,15 @@ describe('Unit tests for AlphaDiversityComputationCtrl', function() {
  			it('should set the alpha diversity to the controller and start the initiation of mean and' +
 				 ' standard deviation of the selected samples', function() {
 				spyOn(ctrl, 'computeMeanAndStandardDeviationOfSelectedSamples_');
-				httpMock.expectGET(expectedUrl).respond(201, '3.46');
+				httpMock.expectGET(expectedUrl).respond(201, {
+					alphaDiversity: '3.46',
+					normalizedAlphaDiversity: '1.23'
+				});
 				ctrl.computeAlphaDiversity(actualSample);
 				httpMock.flush();
 				expect(actualSample.alphaDiversityComputationStatus.completed).toBe(true);
 				expect(actualSample.alphaDiversity).toBe('3.46');
+				expect(actualSample.normalizedAlphaDiversity).toBe('1.23');
 				expect(ctrl.computeMeanAndStandardDeviationOfSelectedSamples_).toHaveBeenCalled();
 			}); 				
 		});

--- a/test/server/server-test.js
+++ b/test/server/server-test.js
@@ -236,7 +236,8 @@ describe('Integration Tests', function() {
 					.get('/compute-alpha-diversity?apiKey=42b357bd1b5f46f88d3cc157f7919d2d&sampleId=0d25bce4f7a445f0&orderOfDiversity=2')
 					.end(function(err, res) {
 						assert.equal(res.statusCode, 200);
-						assert.equal(util.precisionRound(+res.text, 8), 6.60598583);
+						assert.equal(util.precisionRound(+res.body.alphaDiversity, 8), 6.60598583);
+						assert.equal(res.body.normalizedAlphaDiversity, 'undefined');
 						done();
 				});
 		});		
@@ -247,7 +248,8 @@ describe('Integration Tests', function() {
 					.get('/compute-alpha-diversity?apiKey=42b357bd1b5f46f88d3cc157f7919d2d&sampleId=0d25bce4f7a445f0&orderOfDiversity=1')
 					.end(function(err, res) {
 						assert.equal(res.statusCode, 200);
-						assert.equal(util.precisionRound(+res.text, 8), 1.99453478);
+						assert.equal(util.precisionRound(+res.body.alphaDiversity, 8), 1.99453478);
+						assert.equal(util.precisionRound(+res.body.normalizedAlphaDiversity, 8), 0.77761176);
 						done();
 				});
 		});	


### PR DESCRIPTION
Note that an alpha-diversity can be normalized only if the order of diversity, i.e. q is strictly - 1.